### PR TITLE
Add pypi publish workflow mirroring npmjs publish

### DIFF
--- a/.github/actions/publish-to-npmjs/action.yaml
+++ b/.github/actions/publish-to-npmjs/action.yaml
@@ -1,4 +1,5 @@
 name: "Publish to npmjs"
+description: "Publish package to npmjs registry"
 
 inputs:
   registry_token:

--- a/.github/actions/publish-to-pypi/action.yaml
+++ b/.github/actions/publish-to-pypi/action.yaml
@@ -1,0 +1,57 @@
+name: "Publish to PyPI"
+description: "Publish package to PyPI registry"
+
+inputs:
+  registry_token:
+    description: "PyPI token"
+    required: true
+  working-directory:
+    description: "Working directory"
+    required: false
+    default: "."
+  python-version:
+    description: "Python version"
+    required: false
+    default: "3.11"
+
+outputs:
+  published:
+    description: "Whether package was published"
+    value: ${{ steps.publish.outputs.published }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+
+    - name: Install dependencies
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: uv sync
+
+    - name: Build
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: uv build
+
+    - name: Publish to PyPI
+      shell: bash
+      id: publish
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        uv publish --publish-url https://upload.pypi.org/legacy/ 2>&1 | tee publish.log
+        if grep -q "Uploaded" publish.log; then
+          echo "published=true" >> $GITHUB_OUTPUT
+        else
+          echo "published=false" >> $GITHUB_OUTPUT
+        fi
+      env:
+        UV_PUBLISH_TOKEN: ${{ inputs.registry_token }}

--- a/.github/actions/publish-to-pypi/action.yaml
+++ b/.github/actions/publish-to-pypi/action.yaml
@@ -47,7 +47,7 @@ runs:
       id: publish
       working-directory: ${{ inputs.working-directory }}
       run: |
-        uv publish --publish-url https://upload.pypi.org/legacy/ 2>&1 | tee publish.log
+        uv publish 2>&1 | tee publish.log
         if grep -q "Uploaded" publish.log; then
           echo "published=true" >> $GITHUB_OUTPUT
         else

--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -1,5 +1,6 @@
 name: "Setup Node and pnpm"
 description: "Setup Node.js and pnpm, install dependencies and build"
+
 inputs:
   node-version:
     description: "Node.js version"

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -1,0 +1,38 @@
+name: "Publish Python package to PyPI"
+
+on:
+  release:
+    types: [released]
+  workflow_run:
+    workflows: [Create release]
+    types:
+      - completed
+
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "The release tag to checkout"
+        required: true
+
+jobs:
+  publish-python:
+    name: "[🎯 API-CLIENT] Publish to PyPI"
+    if: |
+      contains(github.event.release.tag_name, 'python-v') &&
+      github.head_ref != 'release-please--branches--master' && !contains(github.event.pull_request.labels.*.name, 'autorelease') && 
+      github.event_name == 'workflow_dispatch' || github.event_name == 'release' || 
+      (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.outputs.new_version)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || github.event.inputs.release_tag || github.sha }}
+
+      - uses: ./.github/actions/publish-to-pypi
+        id: publish
+        with:
+          registry_token: ${{ secrets.PYPI_TOKEN }}
+          working-directory: ./python

--- a/python/README.md
+++ b/python/README.md
@@ -2,9 +2,18 @@
 
 Official Python SDK for the [Factorial API](https://apidoc.factorialhr.com).
 
-Auto-generated from the OpenAPI spec with a generated `FactorialClient` wrapper
-providing clean domain-namespaced access, cursor pagination helpers, and both sync
-and async support.
+
+## Versioning
+
+The SDK uses standard semver (`MAJOR.MINOR.PATCH`), independent of the Factorial API version date.
+
+| SDK version | Factorial API version |
+|-------------|----------------------|
+| `1.x.y`     | `2026-04-01`         |
+
+Factorial releases new API versions quarterly (Jan/Apr/Jul/Oct).
+
+See the [Factorial API versioning docs](https://apidoc.factorialhr.com/docs/api-versioning) for details.
 
 ## Installation
 
@@ -82,57 +91,4 @@ for emp in client.employees.employee.paginate(max_items=50):
 
 # Collect everything (use carefully on large datasets)
 all_leaves = client.timeoff.leave.all()
-```
-
-## Versioning
-
-The SDK uses standard semver (`MAJOR.MINOR.PATCH`), independent of the Factorial API version date.
-
-| SDK version | Factorial API version |
-|-------------|----------------------|
-| `1.x.y`     | `2026-04-01`         |
-
-Factorial releases new API versions quarterly (Jan/Apr/Jul/Oct). Each version is supported for one year.
-
-## Release
-
-```bash
-# Dry run (shows what would change, no writes)
-uv run python scripts/release.py --dry-run
-
-# Full release — patch bump (default)
-uv run python scripts/release.py
-
-# Minor or major bump
-uv run python scripts/release.py --bump minor
-uv run python scripts/release.py --bump major
-
-# Supply API version non-interactively
-uv run python scripts/release.py --version 2026-07-01
-```
-
-The release script:
-1. Prompts for the API version date (`yyyy-mm-dd`).
-2. Fetches and patches the spec from `https://api.factorialhr.com/oas/?version=<date>`.
-3. Regenerates `factorial_api_client/generated/` and `client.py`.
-4. Bumps the SDK semver (`--bump major|minor|patch`, default `patch`).
-5. Builds the package, then asks whether to publish to PyPI.
-
-## Smoke test
-
-```bash
-FACTORIAL_API_KEY=xxx uv run python scripts/test_api.py
-```
-
-## Development
-
-```bash
-# Install dependencies
-uv sync
-
-# Type check
-uv run mypy factorial_api_client --ignore-missing-imports
-
-# Lint
-uv run ruff check factorial_api_client
 ```

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,6 +40,9 @@ dev = [
 [tool.hatch.build.targets.wheel]
 packages = ["factorial_api_client"]
 
+[tool.hatch.build.targets.sdist]
+include = ["factorial_api_client/"]
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
## 🚪 Why?

[why]: # (✍️ _What needs is this Pull Request solving or how is it improving the product?_)

New generated Factorial Public API SDKs isn't released to PyPI. This allows to publish to the marketplace automatically after the creation of a release in GitHub.

## 🔑 What?

[what]: # (✍️ _What changes is this Pull Request introducing in the code?_) 

- Added workflows to publish python package to PyPI ecosystem.
- Secret already added to GitHub Actions.
- Cropped README to not include unnecessary instructions in distributed package.
- Removed `scripts/` from being included in the distributed version.

## 🏡 Context

- [💼 Jira](https://factorialmakers.atlassian.net/jira/software/c/projects/FCT/boards/3026?selectedIssue=FCT-55928)
