### PR TITLE
chore: release 1.1.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,4 @@
 {
-  "typescript": "1.1.0",
-  "python": "1.1.0"
+  "typescript": "1.1.1",
+  "python": "1.1.1"
 }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "factorial-api-client"
-version = "1.1.0"
+version = "1.1.1"
 description = "Official Python SDK for the Factorial API"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "factorial-api-client"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/api-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Official TypeScript SDK for the Factorial API",
   "type": "module",
   "main": "./dist/cjs/index.js",


### PR DESCRIPTION
## 🚪 Why?

[why]: # (✍️ _What needs is this Pull Request solving or how is it improving the product?_)

- `1.1.1` is already live on npm and PyPI: it was published via a manual workflow to test the new release process

## 🔑 What?

[what]: # (✍️ _What changes is this Pull Request introducing in the code?_) 

Syncs `main` to the already-published `1.1.1` release:

- `typescript/package.json` → `1.1.1`
- `python/pyproject.toml` + `python/uv.lock` → `1.1.1`
- `.release-please-manifest.json` → `1.1.1` (both packages)

