### PR TITLE
ci: make beta-publish verification resilient to registry propagation lag

### DIFF
--- a/.github/actions/publish-to-pypi/action.yaml
+++ b/.github/actions/publish-to-pypi/action.yaml
@@ -39,12 +39,18 @@ runs:
       run: |
         PACKAGE=$(grep -E '^name = ' pyproject.toml | head -1 | sed -E 's/^name = "(.*)"/\1/')
         VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/^version = "(.*)"/\1/')
-        CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/$PACKAGE/$VERSION/json")
-        if [ "$CODE" = "200" ]; then
+        # Use the simple index (what pip reads) as the existence signal, NOT the
+        # per-version JSON endpoint — that endpoint lags behind upload and can
+        # negative-cache a 404, which would wrongly trigger a duplicate re-upload
+        # (and a hard PyPI rejection) on a re-run. Match the exact sdist filename
+        # to avoid substring false-positives across versions.
+        NORM=$(echo "$PACKAGE" | tr '[:upper:]' '[:lower:]' | sed -E 's/[._-]+/-/g')
+        FNAME_BASE=$(echo "$NORM" | tr '-' '_')
+        if curl -fsS "https://pypi.org/simple/$NORM/" | grep -qF "${FNAME_BASE}-${VERSION}.tar.gz"; then
           echo "✅ $PACKAGE $VERSION is already on PyPI — skipping publish."
           echo "skip=true" >> "$GITHUB_OUTPUT"
         else
-          echo "$PACKAGE $VERSION is not yet on PyPI (HTTP $CODE) — proceeding."
+          echo "$PACKAGE $VERSION is not yet on PyPI — proceeding."
           echo "skip=false" >> "$GITHUB_OUTPUT"
         fi
 

--- a/.github/workflows/beta-publish.yaml
+++ b/.github/workflows/beta-publish.yaml
@@ -129,8 +129,12 @@ jobs:
           registry_token: ${{ secrets.PYPI_TOKEN }}
           working-directory: ./python
 
-      # ── Safety net + record state. ──
-      - name: Assert never-latest and both published
+      # ── Safety gate (hard fail): the beta must NEVER become the default
+      #    install. This runs BEFORE recording state and before the registry
+      #    presence check below, so a slow/lagging registry index can never mask
+      #    a 'latest' regression. (Registry presence is verified separately,
+      #    with retries, after state is recorded — see the last step.)
+      - name: Assert npm 'latest' did not move to the beta
         run: |
           set -euo pipefail
           LATEST=$(npm view @factorialco/api-client dist-tags.latest)
@@ -139,9 +143,7 @@ jobs:
             echo "::error::npm 'latest' moved to the beta version — aborting." >&2
             exit 1
           fi
-          npm view "@factorialco/api-client@$NPM_VERSION" version > /dev/null
-          curl -fsS "https://pypi.org/pypi/factorial-api-client/$PYPI_VERSION/json" > /dev/null
-          echo "✅ beta present on both registries; latest unchanged."
+          echo "✅ npm 'latest' is unchanged ($LATEST) — beta stays opt-in only."
 
       - name: Record beta state on the beta-state branch
         # Push beta_state.json to a dedicated, unprotected orphan branch (never
@@ -179,6 +181,38 @@ jobs:
             git -C "$tmp" commit -m "chore(beta): record $NPM_VERSION"
             git -C "$tmp" push origin beta-state
           fi
+
+      # ── Confirm both registries actually serve the beta. Registry read paths
+      #    lag behind upload (PyPI's CDN can negative-cache a pre-index 404 for
+      #    a while), so poll reliable, fast-updating endpoints with retries
+      #    instead of hitting a per-version URL once: `npm view` for npm, and the
+      #    SIMPLE INDEX (what pip reads) for PyPI, matched on the exact sdist
+      #    filename. Runs AFTER state is recorded, so a slow index here can never
+      #    drop the iteration baseline.
+      - name: Verify beta present on npm and PyPI
+        run: |
+          set -uo pipefail
+          ATTEMPTS=10
+          npm_ok=false
+          for i in $(seq 1 "$ATTEMPTS"); do
+            if npm view "@factorialco/api-client@$NPM_VERSION" version >/dev/null 2>&1; then
+              npm_ok=true; echo "✅ npm serves $NPM_VERSION (attempt $i)."; break
+            fi
+            echo "npm not visible yet ($i/$ATTEMPTS) — retrying in 6s…"; sleep 6
+          done
+          pypi_ok=false
+          PYPI_SDIST="factorial_api_client-${PYPI_VERSION}.tar.gz"
+          for i in $(seq 1 "$ATTEMPTS"); do
+            if curl -fsS "https://pypi.org/simple/factorial-api-client/" | grep -qF "$PYPI_SDIST"; then
+              pypi_ok=true; echo "✅ PyPI simple index lists $PYPI_SDIST (attempt $i)."; break
+            fi
+            echo "PyPI not visible yet ($i/$ATTEMPTS) — retrying in 6s…"; sleep 6
+          done
+          if [ "$npm_ok" != "true" ] || [ "$pypi_ok" != "true" ]; then
+            echo "::error::beta not visible after $ATTEMPTS retries (npm_ok=$npm_ok pypi_ok=$pypi_ok)." >&2
+            exit 1
+          fi
+          echo "✅ beta present on both registries; latest unchanged."
 
   cleanup-beta-tag:
     name: "Clean up stale npm beta tag"


### PR DESCRIPTION
## Why

The first beta deploy worked — npm `2.0.0-beta.2026070100` and PyPI `2.0.0b2026070100` are live, `latest` stayed `1.3.0`. But the run went **red** on the final check and skipped recording state. This fixes that flaky check.

## What

- Verify the publish by polling `npm view` + the PyPI **simple index** (with retries), instead of curling PyPI's per-version JSON once.
- Record the beta-state baseline **before** that check, so a slow registry can't lose it.
- Same fix in the `publish-to-pypi` action's "already published?" check, so re-runs skip cleanly instead of attempting a duplicate upload.

`.github/`-only — no package release.

## Context

Proof it published fine:
- 📦 npm — [`@factorialco/api-client@2.0.0-beta.2026070100`](https://www.npmjs.com/package/@factorialco/api-client/v/2.0.0-beta.2026070100)
- 🐍 PyPI — [`factorial-api-client 2.0.0b2026070100`](https://pypi.org/project/factorial-api-client/2.0.0b2026070100/)
- ❌ the red run — [Actions run #28019594577](https://github.com/factorialco/factorial-api-sdks/actions/runs/28019594577)

The publish succeeded; only the verification failed:

```
npm latest is: 1.3.0                                    ← passed
curl ...pypi.org/.../2.0.0b2026070100/json → 404        ← failed here
```

PyPI's per-version JSON endpoint lags right after upload (and CDN-caches the 404), so it 404'd on a package that was already live. Because that step failed, "Record beta state" never ran — so the `beta-state` branch was never created.

**After merge:** re-run "Publish beta SDKs" (no inputs) — publishes skip, verify passes, and it finally writes the `beta-state` baseline.
